### PR TITLE
pep8 fixed: "Separate top-level function and class definitions with two blank lines."

### DIFF
--- a/letusorderit/ordermgmt/serializers.py
+++ b/letusorderit/ordermgmt/serializers.py
@@ -2,10 +2,12 @@ from rest_framework.serializers import ModelSerializer
 
 from .models import Order, OrderItem
 
+
 class OrderSerializer(ModelSerializer):
 
     class Meta():
         model = Order
+
 
 class OrderItemSerializer(ModelSerializer):
 

--- a/letusorderit/ordermgmt/views.py
+++ b/letusorderit/ordermgmt/views.py
@@ -3,10 +3,12 @@ from rest_framework.viewsets import ModelViewSet
 from .models import Order, OrderItem
 from .serializers import OrderSerializer, OrderItemSerializer
 
+
 class OrderViewSet(ModelViewSet):
 
     queryset = Order.objects.all()
     serializer_class = OrderSerializer
+
 
 class OrderItemViewSet(ModelViewSet):
 


### PR DESCRIPTION
(merge only in workshop!)
